### PR TITLE
Recognize long literals on 32-bit platforms.

### DIFF
--- a/titus/titus/reader.py
+++ b/titus/titus/reader.py
@@ -568,7 +568,7 @@ def _readArgument(data, dot, avroTypeBuilder):
         return LiteralNull(dot)
     elif isinstance(data, bool):
         return LiteralBoolean(data, dot)
-    elif isinstance(data, int):
+    elif isinstance(data, (int, long)):
         if -2147483648 <= data <= 2147483647:
             return LiteralInt(data, dot)
         elif -9223372036854775808 <= data <= 9223372036854775807:


### PR DESCRIPTION
Fix for failure of testPackUnsignedBigEndian on 32-bit platforms.

```bash
$ uname --hardware-platform
i686

$ python setup.py test --test-suite test.testGenpy.TestGeneratePython.testPackUnsignedBigEndian
running test
running egg_info
writing pbr to titus.egg-info/pbr.json
writing requirements to titus.egg-info/requires.txt
writing titus.egg-info/PKG-INFO
writing top-level names to titus.egg-info/top_level.txt
writing dependency_links to titus.egg-info/dependency_links.txt
reading manifest file 'titus.egg-info/SOURCES.txt'
writing manifest file 'titus.egg-info/SOURCES.txt'
running build_ext
testPackUnsignedBigEndian (test.testGenpy.TestGeneratePython) ... ERROR

======================================================================
ERROR: testPackUnsignedBigEndian (test.testGenpy.TestGeneratePython)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/verdi/hadrian/titus/test/testGenpy.py", line 1991, in testPackUnsignedBigEndian
    ''')
  File "/home/verdi/hadrian/titus/titus/genpy.py", line 1589, in fromYaml
    return PFAEngine.fromAst(titus.reader.yamlToAst(src), options, version, sharedState, multiplicity, style, debug)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 195, in yamlToAst
    return jsonToAst(obj)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 112, in jsonToAst
    result = _readEngineConfig(jsonInput, avroTypeBuilder)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 340, in _readEngineConfig
    _action = [_readExpression(data[key], key, avroTypeBuilder)]
  File "/home/verdi/hadrian/titus/titus/reader.py", line 547, in _readExpression
    out = _readArgument(data, dot, avroTypeBuilder)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 718, in _readArgument
    elif key == "pack": _pack = _readStringExpressionPairs(data[key], dot + " -> " + key, avroTypeBuilder)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 434, in _readStringExpressionPairs
    pair = _readExpressionMap(item, dot + " -> " + str(i), avroTypeBuilder)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 511, in _readExpressionMap
    return dict((k, _readExpression(v, dot + " -> " + k, avroTypeBuilder)) for k, v in data.items() if k != "@")
  File "/home/verdi/hadrian/titus/titus/reader.py", line 511, in <genexpr>
    return dict((k, _readExpression(v, dot + " -> " + k, avroTypeBuilder)) for k, v in data.items() if k != "@")
  File "/home/verdi/hadrian/titus/titus/reader.py", line 547, in _readExpression
    out = _readArgument(data, dot, avroTypeBuilder)
  File "/home/verdi/hadrian/titus/titus/reader.py", line 812, in _readArgument
    raise PFASyntaxException("expected expression, not " + _trunc(repr(data)), dot)
PFASyntaxException: PFA syntax error action -> pack -> 5 -> unsigned int: expected expression, not 4294967295L

----------------------------------------------------------------------
Ran 1 test in 0.065s

FAILED (errors=1)
```
