### PR TITLE
moving to ejml 0.25

### DIFF
--- a/hadrian/pom.xml
+++ b/hadrian/pom.xml
@@ -120,7 +120,7 @@ limitations under the License.
     <dependency>
         <groupId>com.googlecode.efficient-java-matrix-library</groupId>
         <artifactId>ejml</artifactId>
-        <version>0.24</version>
+        <version>0.25</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
0.24 is licensed as LGPL, which requires that distributions including
hadrian also distribute the source for EJML. 0.25 is Apache 2.0, which
lines up more neatly.

Tests pass, so I'm hoping that is sufficient and there was no particular
reason to use 0.24 for which 0.25 is ineligible. Later versions have
changed relevant classes.